### PR TITLE
Acrescenta método para recuperar o histórico de execuções

### DIFF
--- a/lib/scorm_cloud/registration_service.rb
+++ b/lib/scorm_cloud/registration_service.rb
@@ -1,7 +1,7 @@
 module ScormCloud
   class RegistrationService < BaseService
     not_implemented :get_registration_list_results,
-      :get_launch_history, :get_launch_info, :reset_global_objectives,
+      :get_launch_info, :reset_global_objectives,
       :update_learner_info, :test_registration_post_url
 
     def create_registration(course_id, reg_id, first_name, last_name, learner_id, options = {})
@@ -37,6 +37,10 @@ module ScormCloud
         :redirecturl => redirect_url
       })
       connection.launch_url("rustici.registration.launch", params)
+    end
+
+    def get_launch_history(reg_id)
+      connection.call_raw("rustici.registration.getLaunchHistory", { :regid => reg_id })
     end
 
     def reset_registration(reg_id)

--- a/lib/scorm_cloud/registration_service.rb
+++ b/lib/scorm_cloud/registration_service.rb
@@ -28,7 +28,7 @@ module ScormCloud
 
     def get_registration_result(reg_id, format = "course")
       raise "Illegal format argument: #{format}" unless ["course","activity","full"].include?(format)
-      connection.call_raw("rustici.registration.getRegistrationResult", { :regid => reg_id, :format => format })
+      connection.call_raw("rustici.registration.getRegistrationResult", { :regid => reg_id, :resultsformat => format })
     end
 
     def launch(reg_id, redirect_url, options = {})

--- a/lib/scorm_cloud/version.rb
+++ b/lib/scorm_cloud/version.rb
@@ -1,3 +1,3 @@
 module ScormCloud
-  VERSION = "0.0.7"
+  VERSION = "0.0.8"
 end


### PR DESCRIPTION
- Acrescenta método para recuperar o histórico de execuções:

```
def get_launch_history(reg_id)
  connection.call_raw("rustici.registration.getLaunchHistory", { :regid => reg_id })
end
```

- Corrige método que recuperar os resultados de um `registrations`:

```
connection.call_raw("rustici.registration.getRegistrationResult", { :regid => reg_id, :resultsformat => format })
```